### PR TITLE
Issue 1

### DIFF
--- a/Builder/SwaggerResolverBuilder.php
+++ b/Builder/SwaggerResolverBuilder.php
@@ -18,6 +18,9 @@ use Linkin\Bundle\SwaggerResolverBundle\Exception\UndefinedPropertyTypeException
 use Linkin\Bundle\SwaggerResolverBundle\Resolver\SwaggerResolver;
 use Linkin\Bundle\SwaggerResolverBundle\Validator\SwaggerValidatorInterface;
 
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
 class SwaggerResolverBuilder
 {
     /**

--- a/Builder/SwaggerResolverBuilder.php
+++ b/Builder/SwaggerResolverBuilder.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Builder;
+
+use EXSyst\Component\Swagger\Schema;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\UndefinedPropertyTypeException;
+use Linkin\Bundle\SwaggerResolverBundle\Resolver\SwaggerResolver;
+use Linkin\Bundle\SwaggerResolverBundle\Validator\SwaggerValidatorInterface;
+
+class SwaggerResolverBuilder
+{
+    /**
+     * @var SwaggerValidatorInterface[]
+     */
+    private $swaggerValidators;
+
+    /**
+     * @param SwaggerValidatorInterface[] $swaggerValidators
+     */
+    public function __construct(array $swaggerValidators)
+    {
+        $this->swaggerValidators = $swaggerValidators;
+    }
+
+    /**
+     * @param Schema $definition
+     * @param string $definitionName
+     *
+     * @return SwaggerResolver
+     *
+     * @throws UndefinedPropertyTypeException
+     */
+    public function build(Schema $definition, string $definitionName): SwaggerResolver
+    {
+        $swaggerResolver = new SwaggerResolver($definition);
+
+        $requiredProperties = $definition->getRequired();
+
+        if (\is_array($requiredProperties)) {
+            $swaggerResolver->setRequired($requiredProperties);
+        }
+
+        $propertiesCount = $definition->getProperties()->getIterator()->count();
+
+        if (0 === $propertiesCount) {
+            return $swaggerResolver;
+        }
+
+        /** @var Schema $propertySchema */
+        foreach ($definition->getProperties() as $name => $propertySchema) {
+            $swaggerResolver->setDefined($name);
+
+            $allowedTypes = $this->getAllowedTypes($propertySchema);
+
+            if (null === $allowedTypes) {
+                $propertyType = $propertySchema->getType() ?? '';
+
+                throw new UndefinedPropertyTypeException($definitionName, $name, $propertyType);
+            }
+
+            if (!$swaggerResolver->isRequired($name)) {
+                $allowedTypes[] = 'null';
+            }
+
+            $swaggerResolver->setAllowedTypes($name, $allowedTypes);
+
+            if (null !== $propertySchema->getDefault()) {
+                $swaggerResolver->setDefault($name, $propertySchema->getDefault());
+            }
+
+            if (!empty($propertySchema->getEnum())) {
+                $swaggerResolver->setAllowedValues($name, (array) $propertySchema->getEnum());
+            }
+        }
+
+        foreach ($this->swaggerValidators as $validator) {
+            $swaggerResolver->addValidator($validator);
+        }
+
+        return $swaggerResolver;
+    }
+
+    /**
+     * @param Schema $propertySchema
+     *
+     * @return array
+     */
+    private function getAllowedTypes(Schema $propertySchema): ?array
+    {
+        $propertyType = $propertySchema->getType();
+        $allowedTypes = [];
+
+        if ('string' === $propertyType) {
+            $allowedTypes[] = 'string';
+
+            return $allowedTypes;
+        }
+
+        if ('integer' === $propertyType) {
+            $allowedTypes[] = 'integer';
+            $allowedTypes[] = 'int';
+
+            return $allowedTypes;
+        }
+
+        if ('boolean' === $propertyType) {
+            $allowedTypes[] = 'boolean';
+            $allowedTypes[] = 'bool';
+
+            return $allowedTypes;
+        }
+
+        if ('number' === $propertyType) {
+            $allowedTypes[] = 'double';
+            $allowedTypes[] = 'float';
+
+            return $allowedTypes;
+        }
+
+        if ('array' === $propertyType) {
+            $allowedTypes[] = null === $propertySchema->getCollectionFormat() ? 'array' : 'string';
+
+            return $allowedTypes;
+        }
+
+        if ('object' === $propertyType) {
+            $allowedTypes[] = 'object';
+            $allowedTypes[] = 'array';
+
+            return $allowedTypes;
+        }
+
+        if (null === $propertyType && $propertySchema->getRef()) {
+            $ref = $propertySchema->getRef();
+
+            $allowedTypes[] = 'object';
+            $allowedTypes[] = 'array';
+            $allowedTypes[] = $ref;
+
+            return $allowedTypes;
+        }
+
+        return null;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 ### Added
 - Added possibility for creating `SwaggerResolver` object for all defined swagger request parameters.
+- Added `SwaggerConfigurationLoaderInterface` into container as alias for the actual configuration loader service.
 ### Changed
-- Moved `SwaggerResolver` building process into separate service `SwaggerResolverBuilder`.
 - Renamed `services.yml` into `services.yaml`.
 
 ## [0.1.2] - 2018-10-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-## [Unreleased]
+## [Unreleased] [BC]
 ### Added
 - Added possibility for creating `SwaggerResolver` object for all defined swagger request parameters.
 - Added `SwaggerConfigurationLoaderInterface` into container as alias for the actual configuration loader service.
+- Added possibility for use different strategies when performing resolving for the full request.
+- Added new parameter `path_merge_strategy`.
+- Added auto-configuration for the `SwaggerValidatorInterface`.
 ### Changed
 - Renamed `services.yml` into `services.yaml`.
+### Removed
+- Removed compatibility with Symfony lower than 3.4.
 
 ## [0.1.2] - 2018-10-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+### Added
+- Added possibility for creating `SwaggerResolver` object for all defined swagger request parameters.
+### Changed
+- Moved `SwaggerResolver` building process into separate service `SwaggerResolverBuilder`.
+- Renamed `services.yml` into `services.yaml`.
+
 ## [0.1.2] - 2018-10-17
 ### Added
 - Added correct processing of the objects references.

--- a/DependencyInjection/Compiler/SwaggerValidatorCompilerPass.php
+++ b/DependencyInjection/Compiler/SwaggerValidatorCompilerPass.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\DependencyInjection\Compiler;
 
 use Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder;
-use Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -30,6 +28,10 @@ class SwaggerValidatorCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->hasDefinition(SwaggerResolverBuilder::class)) {
+            return;
+        }
+
         $validatorQueue = new \SplPriorityQueue();
 
         foreach ($container->findTaggedServiceIds('linkin_swagger_resolver.validator') as $id => $attributes) {
@@ -42,42 +44,9 @@ class SwaggerValidatorCompilerPass implements CompilerPassInterface
 
         $validators = iterator_to_array($validatorQueue);
 
-        $this->registerSwaggerResolverBuilder($container, $validators);
-        $this->registerSwaggerResolverFactory($container);
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     * @param array $validators
-     */
-    private function registerSwaggerResolverBuilder(ContainerBuilder $container, array $validators): void
-    {
-        if (!$container->hasDefinition(SwaggerResolverBuilder::class)) {
-            return;
-        }
-
         $container
             ->getDefinition(SwaggerResolverBuilder::class)
             ->replaceArgument(0, $validators)
         ;
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     */
-    private function registerSwaggerResolverFactory(ContainerBuilder $container): void
-    {
-        $configurationLoaderId = $container->getParameter('linkin_swagger_resolver.configuration_loader');
-        $container->getParameterBag()->remove('linkin_swagger_resolver.configuration_loader');
-
-        $swaggerFactoryDefinition = new Definition(SwaggerResolverFactory::class);
-        $swaggerFactoryDefinition
-            ->addArgument($container->findDefinition(SwaggerResolverBuilder::class))
-            ->addArgument($container->findDefinition($configurationLoaderId))
-            ->addArgument($container->findDefinition('router'))
-        ;
-
-        $container->setDefinition('linkin_swagger_resolver.factory', $swaggerFactoryDefinition);
-        $container->setAlias(SwaggerResolverFactory::class, 'linkin_swagger_resolver.factory');
     }
 }

--- a/DependencyInjection/Compiler/SwaggerValidatorCompilerPass.php
+++ b/DependencyInjection/Compiler/SwaggerValidatorCompilerPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SwaggerValidatorCompilerPass implements CompilerPassInterface
 {
+    public const TAG = 'linkin_swagger_resolver.validator';
+
     /**
      * {@inheritdoc}
      */
@@ -34,7 +36,7 @@ class SwaggerValidatorCompilerPass implements CompilerPassInterface
 
         $validatorQueue = new \SplPriorityQueue();
 
-        foreach ($container->findTaggedServiceIds('linkin_swagger_resolver.validator') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds(self::TAG) as $id => $attributes) {
             $validatorReference = new Reference($id);
 
             $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\DependencyInjection;
 
+use Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -31,6 +32,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('path_merge_strategy')
+                    ->cannotBeEmpty()
+                    ->defaultValue(StrictMergeStrategy::class)
+                ->end()
                 ->scalarNode('configuration_loader_service')->defaultNull()->end()
                 ->scalarNode('configuration_file')->defaultNull()->end()
                 ->arrayNode('swagger_php')

--- a/DependencyInjection/LinkinSwaggerResolverExtension.php
+++ b/DependencyInjection/LinkinSwaggerResolverExtension.php
@@ -37,7 +37,7 @@ class LinkinSwaggerResolverExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.yml');
+        $loader->load('services.yaml');
 
         $this->registerConfigurationLoader($container, $config);
     }

--- a/Exception/PathNotFoundException.php
+++ b/Exception/PathNotFoundException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Exception;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class PathNotFoundException extends \RuntimeException
+{
+    /**
+     * @param string $path
+     */
+    public function __construct(string $path)
+    {
+        $this->message = sprintf('Swagger path "%s" was not found', $path);
+    }
+}

--- a/Factory/SwaggerResolverFactory.php
+++ b/Factory/SwaggerResolverFactory.php
@@ -13,13 +13,16 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Factory;
 
+use EXSyst\Component\Swagger\Parameter;
 use EXSyst\Component\Swagger\Schema;
 use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder;
 use Linkin\Bundle\SwaggerResolverBundle\Exception\DefinitionNotFoundException;
-use Linkin\Bundle\SwaggerResolverBundle\Exception\UndefinedPropertyTypeException;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\PathNotFoundException;
 use Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface;
 use Linkin\Bundle\SwaggerResolverBundle\Resolver\SwaggerResolver;
-use Linkin\Bundle\SwaggerResolverBundle\Validator\SwaggerValidatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -27,9 +30,9 @@ use Linkin\Bundle\SwaggerResolverBundle\Validator\SwaggerValidatorInterface;
 class SwaggerResolverFactory
 {
     /**
-     * @var Swagger
+     * @var SwaggerResolverBuilder
      */
-    private $configuration;
+    private $builder;
 
     /**
      * @var SwaggerConfigurationLoaderInterface
@@ -37,18 +40,117 @@ class SwaggerResolverFactory
     private $configurationLoader;
 
     /**
-     * @var SwaggerValidatorInterface[]
+     * @var RouterInterface
      */
-    private $swaggerValidators;
+    private $router;
 
     /**
-     * @param SwaggerValidatorInterface[]         $swaggerValidators
-     * @param SwaggerConfigurationLoaderInterface $loader
+     * @var Swagger
      */
-    public function __construct(array $swaggerValidators, SwaggerConfigurationLoaderInterface $loader)
-    {
+    private $swaggerConfiguration;
+
+    /**
+     * @param SwaggerResolverBuilder $builder
+     * @param SwaggerConfigurationLoaderInterface $loader
+     * @param RouterInterface $router
+     */
+    public function __construct(
+        SwaggerResolverBuilder $builder,
+        SwaggerConfigurationLoaderInterface $loader,
+        RouterInterface $router
+    ) {
+        $this->builder = $builder;
         $this->configurationLoader = $loader;
-        $this->swaggerValidators = $swaggerValidators;
+        $this->router = $router;
+    }
+
+    /**
+     * @TODO: Refactor this method and add strategies for merging request parameters
+     *
+     * @param Request $request
+     *
+     * @return SwaggerResolver
+     */
+    public function createForRequest(Request $request): SwaggerResolver
+    {
+        $pathInfo = $this->router->match($request->getPathInfo());
+        $route = $this->router->getRouteCollection()->get($pathInfo['_route']);
+        $routePath = $route->getPath();
+
+        $paths = $this->getSwaggerConfiguration()->getPaths();
+
+        if (!$paths->has($routePath)) {
+            throw new PathNotFoundException($routePath);
+        }
+
+        $requestMethod = strtolower($request->getMethod());
+
+        $swaggerPath = $paths->get($routePath);
+        $swaggerOperation = $swaggerPath->getOperation($requestMethod);
+        $parameters = $swaggerOperation->getParameters();
+
+        $mergedProperties = [];
+        $requiredList = [];
+
+        /** @var Parameter $parameter */
+        foreach ($parameters as $parameter) {
+            if ($parameter->getIn() === 'body') {
+                $parameterSchema = $parameter->getSchema();
+
+                $ref = $parameterSchema->getRef();
+
+                if ($ref) {
+                    $explodedName = explode('/', $ref);
+                    $definitionName = end($explodedName);
+
+                    $refDefinition = $this->getDefinition($definitionName);
+                    $requiredList += $refDefinition->getRequired() ?? [];
+
+                    foreach ($refDefinition->getProperties() as $defName => $defItem) {
+                        $mergedProperties[$defName] = $defItem->toArray();
+                    }
+
+                    continue;
+                }
+
+                // body as object
+                if ($parameterSchema->getType() === 'object') {
+                    $requiredList += $parameterSchema->getRequired() ?? [];
+
+                    foreach ($parameterSchema->getProperties() as $bodyItemName => $currentBodyItem) {
+                        $mergedProperties[$bodyItemName] = $currentBodyItem->toArray();
+                    }
+
+                    continue;
+                }
+
+                // as scalar
+                $asArray = $parameterSchema->toArray();
+                $asArray['in'] = $parameter->getIn();
+                $asArray['name'] = $parameter->getName();
+                $asArray['required'] = $parameter->getRequired();
+
+                $mergedProperties[$parameter->getName()] = $asArray;
+
+                continue;
+            }
+
+            if ($parameter->getRequired() === true) {
+                $requiredList[] = $parameter->getName();
+            }
+
+            $mergedProperties[$parameter->getName()] = $parameter->toArray();
+        }
+
+        $mergedSchema = new Schema();
+        $mergedSchema->merge([
+            'type' => 'object',
+            'description' => '__SwaggerResolver_merged_query_properties__',
+            'properties' => $mergedProperties,
+            'required' => $requiredList,
+        ]);
+
+        return $this->builder->build($mergedSchema, $routePath);
     }
 
     /**
@@ -59,46 +161,20 @@ class SwaggerResolverFactory
     public function createForDefinition(string $definitionName): SwaggerResolver
     {
         $definition = $this->getDefinition($definitionName);
-        $swaggerResolver = new SwaggerResolver($definition);
 
-        $requiredProperties = $definition->getRequired();
+        return $this->builder->build($definition, $definitionName);
+    }
 
-        if (is_array($requiredProperties)) {
-            $swaggerResolver->setRequired($requiredProperties);
+    /**
+     * @return Swagger
+     */
+    private function getSwaggerConfiguration(): Swagger
+    {
+        if (null === $this->swaggerConfiguration) {
+            $this->swaggerConfiguration = $this->configurationLoader->loadConfiguration();
         }
 
-        $propertiesCount = $definition->getProperties()->getIterator()->count();
-
-        if (0 === $propertiesCount) {
-            return $swaggerResolver;
-        }
-
-        /** @var Schema $propertySchema */
-        foreach ($definition->getProperties() as $name => $propertySchema) {
-            $swaggerResolver->setDefined($name);
-
-            $allowedTypes = $this->getAllowedTypes($definitionName, $propertySchema, $name);
-
-            if (!$swaggerResolver->isRequired($name)) {
-                $allowedTypes[] = 'null';
-            }
-
-            $swaggerResolver->setAllowedTypes($name, $allowedTypes);
-
-            if (null !== $propertySchema->getDefault()) {
-                $swaggerResolver->setDefault($name, $propertySchema->getDefault());
-            }
-
-            if (!empty($propertySchema->getEnum())) {
-                $swaggerResolver->setAllowedValues($name, (array) $propertySchema->getEnum());
-            }
-        }
-
-        foreach ($this->swaggerValidators as $validator) {
-            $swaggerResolver->addValidator($validator);
-        }
-
-        return $swaggerResolver;
+        return $this->swaggerConfiguration;
     }
 
     /**
@@ -108,11 +184,7 @@ class SwaggerResolverFactory
      */
     private function getDefinition(string $definitionName): Schema
     {
-        if (null === $this->configuration) {
-            $this->configuration = $this->configurationLoader->loadConfiguration();
-        }
-
-        $definitions = $this->configuration->getDefinitions();
+        $definitions = $this->getSwaggerConfiguration()->getDefinitions();
 
         $explodedName = explode('\\', $definitionName);
         $definitionName = end($explodedName);
@@ -122,68 +194,5 @@ class SwaggerResolverFactory
         }
 
         throw new DefinitionNotFoundException($definitionName);
-    }
-
-    /**
-     * @param string $definition
-     * @param Schema $propertySchema
-     * @param string $name
-     *
-     * @return array
-     */
-    private function getAllowedTypes(string $definition, Schema $propertySchema, string $name): array
-    {
-        $propertyType = $propertySchema->getType();
-        $allowedTypes = [];
-
-        if ('string' === $propertyType) {
-            $allowedTypes[] = 'string';
-
-            return $allowedTypes;
-        }
-
-        if ('integer' === $propertyType) {
-            $allowedTypes[] = 'integer';
-            $allowedTypes[] = 'int';
-
-            return $allowedTypes;
-        }
-
-        if ('boolean' === $propertyType) {
-            $allowedTypes[] = 'boolean';
-            $allowedTypes[] = 'bool';
-
-            return $allowedTypes;
-        }
-
-        if ('number' === $propertyType) {
-            $allowedTypes[] = 'double';
-            $allowedTypes[] = 'float';
-
-            return $allowedTypes;
-        }
-
-        if ('array' === $propertyType) {
-            $allowedTypes[] = null === $propertySchema->getCollectionFormat() ? 'array' : 'string';
-
-            return $allowedTypes;
-        }
-
-        if ('object' === $propertyType) {
-            $allowedTypes[] = 'object';
-
-            return $allowedTypes;
-        }
-
-        if (null === $propertyType && $propertySchema->getRef()) {
-            $ref = $propertySchema->getRef();
-
-            $allowedTypes[] = 'object';
-            $allowedTypes[] = $ref;
-
-            return $allowedTypes;
-        }
-
-        throw new UndefinedPropertyTypeException($definition, $name, (string) $propertyType);
     }
 }

--- a/Merger/MergeStrategyInterface.php
+++ b/Merger/MergeStrategyInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+interface MergeStrategyInterface
+{
+    /**
+     * Add parameter into collection
+     *
+     * @param string $parameterSource
+     * @param string $name
+     * @param array $data
+     * @param bool $isRequired
+     */
+    public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired);
+
+    /**
+     * Returns list of collected parameters
+     *
+     * @return array
+     */
+    public function getParameters(): array;
+
+    /**
+     * Returns list of names of the required parameters
+     *
+     * @return array
+     */
+    public function getRequired(): array;
+
+    /**
+     * Clean all collected data
+     */
+    public function clean();
+}

--- a/Merger/PathParameterMerger.php
+++ b/Merger/PathParameterMerger.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger;
+
+use EXSyst\Component\Swagger\Collections\Definitions;
+use EXSyst\Component\Swagger\Parameter;
+use EXSyst\Component\Swagger\Path;
+use EXSyst\Component\Swagger\Schema;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class PathParameterMerger
+{
+    /**
+     * @var MergeStrategyInterface
+     */
+    private $defaultMergeStrategy;
+
+    /**
+     * @param MergeStrategyInterface $defaultMergeStrategy
+     */
+    public function __construct(MergeStrategyInterface $defaultMergeStrategy)
+    {
+        $this->defaultMergeStrategy = $defaultMergeStrategy;
+    }
+
+    /**
+     * @param Path $swaggerPath
+     * @param string $requestMethod
+     * @param Definitions $definitions
+     * @param MergeStrategyInterface|null $mergeStrategy
+     *
+     * @return Schema
+     */
+    public function merge(
+        Path $swaggerPath,
+        string $requestMethod,
+        Definitions $definitions,
+        ?MergeStrategyInterface $mergeStrategy = null
+    ): Schema {
+        if (!$mergeStrategy) {
+            $mergeStrategy = $this->defaultMergeStrategy;
+        }
+
+        $swaggerOperation = $swaggerPath->getOperation($requestMethod);
+
+        /** @var Parameter $parameter */
+        foreach ($swaggerOperation->getParameters() as $parameter) {
+            if ($parameter->getIn() !== 'body') {
+                $mergeStrategy->addParameter(
+                    $parameter->getIn(),
+                    $parameter->getName(),
+                    $parameter->toArray(),
+                    $parameter->getRequired() === true
+                );
+
+                continue;
+            }
+
+            $parameterSchema = $parameter->getSchema();
+
+            $ref = $parameterSchema->getRef();
+
+            // body as reference
+            if ($ref) {
+                $explodedName = explode('/', $ref);
+                $definitionName = end($explodedName);
+
+                $refDefinition = $definitions->get($definitionName);
+                $required = $refDefinition->getRequired() ?? [];
+                $required = array_flip($required);
+
+                foreach ($refDefinition->getProperties() as $defName => $defItem) {
+                    $mergeStrategy->addParameter(
+                        $parameter->getIn(),
+                        $defName,
+                        $defItem->toArray(),
+                        isset($required[$defName])
+                    );
+                }
+
+                continue;
+            }
+
+            // body as object
+            if ($parameterSchema->getType() === 'object') {
+                $required = $parameterSchema->getRequired() ?? [];
+                $required = array_flip($required);
+
+                foreach ($parameterSchema->getProperties() as $bodyItemName => $currentBodyItem) {
+                    $mergeStrategy->addParameter(
+                        $parameter->getIn(),
+                        $bodyItemName,
+                        $currentBodyItem->toArray(),
+                        isset($required[$bodyItemName])
+                    );
+                }
+
+                continue;
+            }
+
+            // body as scalar
+            $mergeStrategy->addParameter(
+                $parameter->getIn(),
+                $parameter->getName(),
+                $parameterSchema->toArray(),
+                $parameter->getRequired() === true
+            );
+        }
+
+        $mergedSchema = new Schema();
+        $mergedSchema->merge([
+            'type' => 'object',
+            'properties' => $mergeStrategy->getParameters(),
+            'required' => $mergeStrategy->getRequired(),
+        ]);
+
+        $mergeStrategy->clean();
+
+        return $mergedSchema;
+    }
+}

--- a/Merger/Strategy/AbstractMergeStrategy.php
+++ b/Merger/Strategy/AbstractMergeStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy;
+
+use Linkin\Bundle\SwaggerResolverBundle\Merger\MergeStrategyInterface;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+abstract class AbstractMergeStrategy implements MergeStrategyInterface
+{
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @var array
+     */
+    protected $required;
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequired(): array
+    {
+        return $this->required;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clean()
+    {
+        $this->parameters = [];
+        $this->required = [];
+    }
+}

--- a/Merger/Strategy/CombineNameMergeStrategy.php
+++ b/Merger/Strategy/CombineNameMergeStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class CombineNameMergeStrategy extends AbstractMergeStrategy
+{
+    public const DELIMITER = '_';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired)
+    {
+        $name = $parameterSource . self::DELIMITER . $name;
+
+        if ($isRequired) {
+            $this->required[$name] = $name;
+        }
+
+        $this->parameters[$name] = $data;
+    }
+}

--- a/Merger/Strategy/ReplaceFirstWinMergeStrategy.php
+++ b/Merger/Strategy/ReplaceFirstWinMergeStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class ReplaceFirstWinMergeStrategy extends AbstractMergeStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired)
+    {
+        if (isset($this->parameters[$name])) {
+            return;
+        }
+
+        if ($isRequired) {
+            $this->required[$name] = $name;
+        }
+
+        $this->parameters[$name] = $data;
+    }
+}

--- a/Merger/Strategy/ReplaceLastWinMergeStrategy.php
+++ b/Merger/Strategy/ReplaceLastWinMergeStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class ReplaceLastWinMergeStrategy extends AbstractMergeStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired)
+    {
+        if ($isRequired) {
+            $this->required[$name] = $name;
+        }
+
+        $this->parameters[$name] = $data;
+    }
+}

--- a/Merger/Strategy/StrictMergeStrategy.php
+++ b/Merger/Strategy/StrictMergeStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy;
+
+use Exception;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class StrictMergeStrategy extends AbstractMergeStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function addParameter(string $parameterSource, string $name, array $data, bool $isRequired)
+    {
+        if (isset($this->parameters[$name])) {
+            throw new Exception(sprintf(
+                'Parameter "%s" has duplicate. Rename parameter or use another merger strategy',
+                $name
+            ));
+        }
+
+        if ($isRequired) {
+            $this->required[$name] = $name;
+        }
+
+        $this->parameters[$name] = $data;
+    }
+}

--- a/README.RU.md
+++ b/README.RU.md
@@ -74,6 +74,8 @@ class AppKernel extends Kernel
 ```yaml
 # app/config.yml
 linkin_swagger_resolver:
+    # стратегия по умолчанию для слияния параметров запроса
+    path_merge_strategy:            Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy
     configuration_loader_service:   ~   # имя сервиса загрузки конфигурации
     configuration_file:             ~   # полный путь к файлу конфигурации
     swagger_php:                        # настройки для swagger-php
@@ -144,7 +146,9 @@ linkin_swagger_resolver:
     configuration_loader_service: acme_app.custom_configuration_loader
 ```
 
-### Шаг 2: Валидация моделей
+### Шаг 2: Валидация данных
+
+#### Валидация модели
 
 ```php
 <?php
@@ -157,6 +161,20 @@ $swaggerResolver = $factory->createForDefinition(AcmeApiModel::class);
 $swaggerResolver = $factory->createForDefinition('AcmeApiModel');
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
+$data = $swaggerResolver->resolve(json_decode($request->getContent(), true));
+```
+
+#### Валидация всего запроса
+
+```php
+<?php
+
+/** @var \Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory $factory */
+$factory = $container->get('linkin_swagger_resolver.factory');
+$request = $container->get('request_stack')->getCurrentRequest();
+// загрузка всех параметров вызванного метода запроса
+$swaggerResolver = $factory->createForRequest($request);
+
 $data = $swaggerResolver->resolve(json_decode($request->getContent(), true));
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ All parameters has values by default:
 ```yaml
 # app/config.yml
 linkin_swagger_resolver:
+    # default strategy for merge all request parameters.
+    path_merge_strategy:            Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy
     configuration_loader_service:   ~   # the name of the configuration loader service
     configuration_file:             ~   # full path to the configuration file
     swagger_php:                        # settings for the swagger-php
@@ -145,7 +147,9 @@ linkin_swagger_resolver:
     configuration_loader_service: acme_app.custom_configuration_loader
 ```
 
-### Step 2: Models validation
+### Step 2: Data validation
+
+#### Validation for model
 
 ```php
 <?php
@@ -158,6 +162,20 @@ $swaggerResolver = $factory->createForDefinition(AcmeApiModel::class);
 $swaggerResolver = $factory->createForDefinition('AcmeApiModel');
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
+$data = $swaggerResolver->resolve(json_decode($request->getContent(), true));
+```
+
+#### Validation for request
+
+```php
+<?php
+
+/** @var \Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory $factory */
+$factory = $container->get('linkin_swagger_resolver.factory');
+$request = $container->get('request_stack')->getCurrentRequest();
+// Loading by request
+$swaggerResolver = $factory->createForRequest($request);
+
 $data = $swaggerResolver->resolve(json_decode($request->getContent(), true));
 ```
 

--- a/Resolver/SwaggerResolver.php
+++ b/Resolver/SwaggerResolver.php
@@ -51,7 +51,7 @@ class SwaggerResolver extends OptionsResolver
     {
          parent::clear();
 
-        $this->validators = [];
+         $this->validators = [];
 
          return $this;
     }
@@ -82,7 +82,7 @@ class SwaggerResolver extends OptionsResolver
      */
     public function addValidator(SwaggerValidatorInterface $validator): self
     {
-        $className = get_class($validator);
+        $className = \get_class($validator);
 
         $this->validators[$className] = $validator;
 

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -1,4 +1,10 @@
 services:
+    Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder:
+        arguments:
+            - []
+    linkin_swagger_resolver.builder:
+        alias: Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder
+
     linkin_swagger_resolver.loader.configuration:
         class:      Linkin\Bundle\SwaggerResolverBundle\Loader\NelmioApiDocConfigurationLoader
         public:     false

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -5,11 +5,14 @@ services:
     linkin_swagger_resolver.builder:
         alias: Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder
 
-    linkin_swagger_resolver.loader.configuration:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Loader\NelmioApiDocConfigurationLoader
-        public:     false
+    Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
+        public: true
         arguments:
-            - '@nelmio_api_doc.generator'
+            - '@linkin_swagger_resolver.builder'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
+            - '@router'
+    linkin_swagger_resolver.factory:
+        alias: Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory
 
     linkin_swagger_resolver.validator.array.max_items:
         class:      Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayMaxItemsValidator

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -1,93 +1,99 @@
 services:
     Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder:
+        public:     false
         arguments:
             - []
     linkin_swagger_resolver.builder:
-        alias: Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder
+        alias:      Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder
 
     Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
-        public: true
+        public:     true
         arguments:
-            - '@linkin_swagger_resolver.builder'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger'
             - '@router'
     linkin_swagger_resolver.factory:
-        alias: Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory
+        alias:      Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory
 
-    linkin_swagger_resolver.validator.array.max_items:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayMaxItemsValidator
+    Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger:
+        public:     false
+        arguments:
+            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\MergeStrategyInterface'
+
+    Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\CombineNameMergeStrategy:
+        public: false
+
+    Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\ReplaceFirstWinMergeStrategy:
+        public: false
+
+    Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\ReplaceLastWinMergeStrategy:
+        public: false
+
+    Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy:
+        public: false
+
+    Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayMaxItemsValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.array.min_items:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayMinItemsValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayMinItemsValidator:
+        public: false
+        tags:
+            - { name: linkin_swagger_resolver.validator }
+
+    Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayUniqueItemsValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.array.unique_items:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\ArrayUniqueItemsValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\FormatDateValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.format.date:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\FormatDateValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\FormatDateTimeValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.format.date_time:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\FormatDateTimeValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\FormatTimestampValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.format.timestamp:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\FormatTimestampValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\FormatTimeValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.format.time:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\FormatTimeValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMaximumValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.number.maximum:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMaximumValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMinimumValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.number.minimum:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMinimumValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMultipleOfValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.number.multiple_of:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\NumberMultipleOfValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\StringMaxLengthValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.string.max_length:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\StringMaxLengthValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\StringMinLengthValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }
 
-    linkin_swagger_resolver.validator.string.min_length:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\StringMinLengthValidator
-        public:     false
-        tags:
-            - { name: linkin_swagger_resolver.validator }
-
-    linkin_swagger_resolver.validator.string.pattern:
-        class:      Linkin\Bundle\SwaggerResolverBundle\Validator\StringPatternValidator
+    Linkin\Bundle\SwaggerResolverBundle\Validator\StringPatternValidator:
         public:     false
         tags:
             - { name: linkin_swagger_resolver.validator }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "symfony/config":               "~2.8||~3.0||~4.0",
         "symfony/dependency-injection": "~2.8||~3.0||~4.0",
         "symfony/http-kernel":          "~2.8||~3.0||~4.0",
-        "symfony/options-resolver":     "~2.8||~3.0||~4.0"
+        "symfony/options-resolver":     "~2.8||~3.0||~4.0",
+        "symfony/routing":              "~2.8||~3.0||~4.0",
+        "symfony/http-foundation":      "~2.8||~3.0||~4.0"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php":                          "~7.1",
         "exsyst/swagger":               "~0.4",
-        "symfony/config":               "~2.8||~3.0||~4.0",
-        "symfony/dependency-injection": "~2.8||~3.0||~4.0",
-        "symfony/http-kernel":          "~2.8||~3.0||~4.0",
-        "symfony/options-resolver":     "~2.8||~3.0||~4.0",
-        "symfony/routing":              "~2.8||~3.0||~4.0",
-        "symfony/http-foundation":      "~2.8||~3.0||~4.0"
+        "symfony/config":               "~3.4||~4.0",
+        "symfony/dependency-injection": "~3.4||~4.0",
+        "symfony/http-kernel":          "~3.4||~4.0",
+        "symfony/options-resolver":     "~3.4||~4.0",
+        "symfony/routing":              "~3.4||~4.0",
+        "symfony/http-foundation":      "~3.4||~4.0"
     },
 
     "suggest": {


### PR DESCRIPTION
Resolve #1 

### Added
 - Added possibility for creating `SwaggerResolver` object for all defined swagger request parameters.
 - Added `SwaggerConfigurationLoaderInterface` into container as alias for the actual configuration loader service.
 - Added possibility for use different strategies when performing resolving for the full request.
 - Added new parameter `path_merge_strategy`.
 - Added auto-configuration for the `SwaggerValidatorInterface`.
 ### Changed
 - Renamed `services.yml` into `services.yaml`.
 ### Removed
 - Removed compatibility with Symfony lower than 3.4.