### PR TITLE
Issue 5

### DIFF
--- a/Builder/SwaggerResolverBuilder.php
+++ b/Builder/SwaggerResolverBuilder.php
@@ -122,7 +122,7 @@ class SwaggerResolverBuilder
      */
     private function addNormalization(SwaggerResolver $resolver, string $name, Schema $propertySchema): SwaggerResolver
     {
-        /** @see \Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger parameter location in title */
+        /** @see \Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger parameter location in title */
         if (!in_array($propertySchema->getTitle(), $this->normalizationLocations, true)) {
             return $resolver;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+### Changed
+- Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
+- Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.
+
 ## [0.3.0] - 2019-03-03
 ### Added
 - Added normalizers usage and provides possibility for enable this for concrete parameter locations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## [Unreleased]
 ### Added
 - Added symfony cache warmer for the swagger configuration and enable him by default.
+- Added console notification when some api definitions have not reference to the source file.
 - Added automatic cache warm up in the debug mode, according to source file modification.
 - Added composer requirement: `symfony/yaml`.
 ### Changed
 - Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
 - Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.
 - Renamed `PathParameterMerger` into `OperationParameterMerger`.
+- Reworked `SwaggerConfigurationLoaderInterface`.
 
 ## [0.3.0] - 2019-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Changed
 - Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
 - Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.
+- Renamed `PathParameterMerger` into `OperationParameterMerger`.
 
 ## [0.3.0] - 2019-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 ### Added
-- Added symfony cache warmer for the swagger configuration and enabled by default.
+- Added symfony cache warmer for the swagger configuration and enable him by default.
+- Added automatic cache warm up in the debug mode, according to source file modification.
+- Added composer requirement: `symfony/yaml`.
 ### Changed
 - Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
 - Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+- Added symfony cache warmer for the swagger configuration and enabled by default.
 ### Changed
 - Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
 - Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.

--- a/CacheWarmer/SwaggerConfigurationCacheWarmer.php
+++ b/CacheWarmer/SwaggerConfigurationCacheWarmer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\CacheWarmer;
+
+use Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfigurationInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class SwaggerConfigurationCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @var SwaggerConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param SwaggerConfigurationInterface $configurationLoader
+     */
+    public function __construct(SwaggerConfigurationInterface $configurationLoader)
+    {
+        $this->configuration = $configurationLoader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        if ($this->configuration instanceof WarmableInterface) {
+            $this->configuration->warmUp($cacheDir);
+        }
+    }
+}

--- a/Collection/SchemaDefinitionCollection.php
+++ b/Collection/SchemaDefinitionCollection.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Collection;
+
+use ArrayIterator;
+use EXSyst\Component\Swagger\Schema;
+use IteratorAggregate;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\DefinitionNotFoundException;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class SchemaDefinitionCollection implements IteratorAggregate
+{
+    /**
+     * @var Schema[]
+     */
+    private $schemaCollection = [];
+
+    /**
+     * @var FileResource[][]
+     */
+    private $resourceCollection = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->schemaCollection);
+    }
+
+    /**
+     * @param string $definitionName
+     * @param Schema $schema
+     *
+     * @return self
+     */
+    public function addSchema(string $definitionName, Schema $schema): self
+    {
+        $this->schemaCollection[$definitionName] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * @param string $definitionName
+     *
+     * @return Schema
+     *
+     * @throws DefinitionNotFoundException
+     */
+    public function getSchema(string $definitionName): Schema
+    {
+        if (empty($this->schemaCollection[$definitionName])) {
+            throw new DefinitionNotFoundException($definitionName);
+        }
+
+        return $this->schemaCollection[$definitionName];
+    }
+
+    /**
+     * @param string $definitionName
+     * @param FileResource $resource
+     *
+     * @return self
+     */
+    public function addSchemaResource(string $definitionName, FileResource $resource): self
+    {
+        $this->resourceCollection[$definitionName][] = $resource;
+
+        return $this;
+    }
+
+    /**
+     * @param string $definitionName
+     *
+     * @return FileResource[]
+     */
+    public function getSchemaResources(string $definitionName): array
+    {
+        return $this->resourceCollection[$definitionName] ?? [];
+    }
+}

--- a/Collection/SchemaOperationCollection.php
+++ b/Collection/SchemaOperationCollection.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Collection;
+
+use ArrayIterator;
+use EXSyst\Component\Swagger\Schema;
+use IteratorAggregate;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\OperationNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\PathNotFoundException;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class SchemaOperationCollection implements IteratorAggregate
+{
+    /**
+     * @var Schema[][]
+     */
+    private $schemaCollection = [];
+
+    /**
+     * @var FileResource[][]
+     */
+    private $resourceCollection = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->schemaCollection);
+    }
+
+    /**
+     * @param string $path
+     * @param string $method
+     * @param Schema $schema
+     *
+     * @return self
+     */
+    public function addSchema(string $path, string $method, Schema $schema): self
+    {
+        $this->schemaCollection[$path][$method] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * @param string $path
+     * @param string $method
+     *
+     * @return Schema
+     *
+     * @throws OperationNotFoundException
+     * @throws PathNotFoundException
+     */
+    public function getSchema(string $path, string $method): Schema
+    {
+        if (empty($this->schemaCollection[$path])) {
+            throw new PathNotFoundException($path);
+        }
+
+        if (empty($this->schemaCollection[$path][$method])) {
+            throw new OperationNotFoundException($path, $method);
+        }
+
+        return $this->schemaCollection[$path][$method];
+    }
+
+    /**
+     * @param string $path
+     * @param FileResource $resource
+     *
+     * @return self
+     */
+    public function addSchemaResource(string $path, FileResource $resource): self
+    {
+        $this->resourceCollection[$path][] = $resource;
+
+        return $this;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return FileResource[]
+     */
+    public function getSchemaResources(string $path): array
+    {
+        return $this->resourceCollection[$path] ?? [];
+    }
+}

--- a/Configuration/SwaggerCachedConfiguration.php
+++ b/Configuration/SwaggerCachedConfiguration.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Configuration;
+
+use EXSyst\Component\Swagger\Path;
+use EXSyst\Component\Swagger\Schema;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use function json_decode;
+use function json_encode;
+use function md5;
+use function sprintf;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class SwaggerCachedConfiguration extends SwaggerConfiguration implements WarmableInterface
+{
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var ConfigCacheFactoryInterface
+     */
+    private $configCacheFactory;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @required
+     *
+     * @param string $cacheDir
+     */
+    public function setCacheDir(string $cacheDir): void
+    {
+        $this->cacheDir = $cacheDir . '/linkin_swagger_resolver';
+    }
+
+    /**
+     * @required
+     *
+     * @param bool $debug
+     */
+    public function setDebugMode(bool $debug): void
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(string $definitionName): Schema
+    {
+        $cache = $this->getConfigCacheFactory()->cache(
+            sprintf('%s/definitions/%s_%s.php', $this->cacheDir, $definitionName, md5($definitionName)),
+            function (ConfigCacheInterface $cache) use ($definitionName) {
+                $this->dumpDefinition($definitionName, $cache);
+            }
+        );
+
+        return include $cache->getPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPathDefinition(string $routePath, string $method): Schema
+    {
+        $cache = $this->getConfigCacheFactory()->cache(
+            sprintf('%s/paths/%s/%s_%s.php', $this->cacheDir, $routePath, $method, md5($routePath . $method)),
+            function (ConfigCacheInterface $cache) use ($routePath, $method) {
+                $this->dumpOperation($routePath, $method, $cache);
+            }
+        );
+
+        return include $cache->getPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        foreach ($this->getSchemaDefinitionList() as $definitionName => $definition) {
+            $this->getDefinition($definitionName);
+        }
+
+        /** @var Path $pathObject */
+        foreach ($this->getSchemaOperationList() as $path => $methodList) {
+            foreach ($methodList as $method => $operation) {
+                $this->getPathDefinition($path, $method);
+            }
+        }
+    }
+
+    /**
+     * @param string $definitionName
+     * @param ConfigCacheInterface $cache
+     */
+    private function dumpDefinition(string $definitionName, ConfigCacheInterface $cache): void
+    {
+        $definition = parent::getDefinition($definitionName);
+
+        $this->dumpSchema($definition, $cache);
+    }
+
+    /**
+     * @param string $path
+     * @param string $method
+     * @param ConfigCacheInterface $cache
+     */
+    private function dumpOperation(string $path, string $method, ConfigCacheInterface $cache): void
+    {
+        $definition = parent::getPathDefinition($path, $method);
+
+        $this->dumpSchema($definition, $cache);
+    }
+
+    /**
+     * @param Schema $schema
+     * @param ConfigCacheInterface $cache
+     */
+    private function dumpSchema(Schema $schema, ConfigCacheInterface $cache): void
+    {
+        $template = <<<EOF
+<?php
+
+declare(strict_types=1);
+
+use EXSyst\Component\Swagger\Schema;
+
+return new Schema(%s);
+
+EOF;
+
+        // to avoid problem with unexpected stdClass
+        $definitionAsArray = json_decode(json_encode($schema->toArray()), true);
+        $definitionExport = var_export($definitionAsArray, true);
+
+        // TODO: Add meta for auto-check is cache fresh in debug mode
+        $cache->write(sprintf($template, $definitionExport));
+    }
+
+    /**
+     * @return ConfigCacheFactoryInterface
+     */
+    private function getConfigCacheFactory(): ConfigCacheFactoryInterface
+    {
+        if (!$this->configCacheFactory) {
+            // TODO: use ConfigCacheFactory when meta info will be implemented
+            $this->configCacheFactory = new ResourceCheckerConfigCacheFactory();
+        }
+
+        return $this->configCacheFactory;
+    }
+}

--- a/Configuration/SwaggerConfiguration.php
+++ b/Configuration/SwaggerConfiguration.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Configuration;
+
+use EXSyst\Component\Swagger\Schema;
+use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\DefinitionNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\PathNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger;
+use function end;
+use function explode;
+use function strtolower;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class SwaggerConfiguration
+{
+    /**
+     * @var Swagger
+     */
+    private $configuration;
+
+    /**
+     * @var SwaggerConfigurationLoaderInterface
+     */
+    private $configurationLoader;
+
+    /**
+     * @var PathParameterMerger
+     */
+    private $parameterMerger;
+
+    /**
+     * @param PathParameterMerger $parameterMerger
+     * @param SwaggerConfigurationLoaderInterface $loader
+     */
+    public function __construct(PathParameterMerger $parameterMerger, SwaggerConfigurationLoaderInterface $loader)
+    {
+        $this->configurationLoader = $loader;
+        $this->parameterMerger = $parameterMerger;
+    }
+
+    /**
+     * @param string $definitionName
+     *
+     * @return Schema
+     *
+     * @throws DefinitionNotFoundException
+     */
+    public function getDefinition(string $definitionName): Schema
+    {
+        $definitions = $this->getConfiguration()->getDefinitions();
+
+        $explodedName = explode('\\', $definitionName);
+        $definitionName = end($explodedName);
+
+        if ($definitions->has($definitionName)) {
+            return $definitions->get($definitionName);
+        }
+
+        throw new DefinitionNotFoundException($definitionName);
+    }
+
+    /**
+     * @param string $routePath
+     * @param string $method
+     *
+     * @return Schema
+     *
+     * @throws PathNotFoundException
+     */
+    public function getPathDefinition(string $routePath, string $method): Schema
+    {
+        $paths = $this->getConfiguration()->getPaths();
+
+        if (!$paths->has($routePath)) {
+            throw new PathNotFoundException($routePath);
+        }
+
+        $definitions = $this->getConfiguration()->getDefinitions();
+        $swaggerPath = $paths->get($routePath);
+        $requestMethod = strtolower($method);
+
+        return $this->parameterMerger->merge($swaggerPath, $requestMethod, $definitions);
+    }
+
+    /**
+     * @return Swagger
+     */
+    private function getConfiguration(): Swagger
+    {
+        if (null === $this->configuration) {
+            $this->configuration = $this->configurationLoader->loadConfiguration();
+        }
+
+        return $this->configuration;
+    }
+}

--- a/Configuration/SwaggerConfiguration.php
+++ b/Configuration/SwaggerConfiguration.php
@@ -13,13 +13,8 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Configuration;
 
-use EXSyst\Component\Swagger\Path;
 use EXSyst\Component\Swagger\Schema;
-use Linkin\Bundle\SwaggerResolverBundle\Exception\DefinitionNotFoundException;
-use Linkin\Bundle\SwaggerResolverBundle\Exception\OperationNotFoundException;
-use Linkin\Bundle\SwaggerResolverBundle\Exception\PathNotFoundException;
 use Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface;
-use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -32,28 +27,11 @@ class SwaggerConfiguration implements SwaggerConfigurationInterface
     private $configurationLoader;
 
     /**
-     * @var OperationParameterMerger
-     */
-    private $parameterMerger;
-
-    /**
-     * @var Schema[]
-     */
-    private $schemaDefinitionList;
-
-    /**
-     * @var Schema[]
-     */
-    private $schemaOperationList;
-
-    /**
-     * @param OperationParameterMerger $parameterMerger
      * @param SwaggerConfigurationLoaderInterface $loader
      */
-    public function __construct(OperationParameterMerger $parameterMerger, SwaggerConfigurationLoaderInterface $loader)
+    public function __construct(SwaggerConfigurationLoaderInterface $loader)
     {
         $this->configurationLoader = $loader;
-        $this->parameterMerger = $parameterMerger;
     }
 
     /**
@@ -61,13 +39,7 @@ class SwaggerConfiguration implements SwaggerConfigurationInterface
      */
     public function getDefinition(string $definitionName): Schema
     {
-        $schemaDefinitionList = $this->getSchemaDefinitionList();
-
-        if (isset($schemaDefinitionList[$definitionName])) {
-            return $schemaDefinitionList[$definitionName];
-        }
-
-        throw new DefinitionNotFoundException($definitionName);
+        return $this->configurationLoader->getSchemaDefinitionCollection()->getSchema($definitionName);
     }
 
     /**
@@ -75,60 +47,6 @@ class SwaggerConfiguration implements SwaggerConfigurationInterface
      */
     public function getPathDefinition(string $routePath, string $method): Schema
     {
-        $schemaOperationList = $this->getSchemaOperationList();
-
-        if (empty($schemaOperationList[$routePath])) {
-            throw new PathNotFoundException($routePath);
-        }
-
-        if (empty($schemaOperationList[$routePath][$method])) {
-            throw new OperationNotFoundException($routePath, $method);
-        }
-
-        return $schemaOperationList[$routePath][$method];
-    }
-
-    /**
-     * @return Schema[]
-     */
-    protected function getSchemaDefinitionList(): array
-    {
-        if ($this->schemaDefinitionList === null) {
-            $this->loadConfiguration();
-        }
-
-        return $this->schemaDefinitionList;
-    }
-
-    /**
-     * @return Schema[]
-     */
-    protected function getSchemaOperationList(): array
-    {
-        if ($this->schemaOperationList === null) {
-            $this->loadConfiguration();
-        }
-
-        return $this->schemaOperationList;
-    }
-
-    /**
-     * Load full configuration
-     */
-    private function loadConfiguration(): void
-    {
-        $configuration = $this->configurationLoader->loadConfiguration();
-        $definitions = $configuration->getDefinitions();
-
-        foreach ($configuration->getDefinitions()->getIterator() as $definitionName => $definition) {
-            $this->schemaDefinitionList[$definitionName] = $definition;
-        }
-
-        /** @var Path $pathObject */
-        foreach ($configuration->getPaths()->getIterator() as $path => $pathObject) {
-            foreach ($pathObject->getOperations() as $method => $operation) {
-                $this->schemaOperationList[$path][$method] = $this->parameterMerger->merge($operation, $definitions);
-            }
-        }
+        return $this->configurationLoader->getSchemaOperationCollection()->getSchema($routePath, $method);
     }
 }

--- a/Configuration/SwaggerConfiguration.php
+++ b/Configuration/SwaggerConfiguration.php
@@ -24,7 +24,7 @@ use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class SwaggerConfiguration
+class SwaggerConfiguration implements SwaggerConfigurationInterface
 {
     /**
      * @var SwaggerConfigurationLoaderInterface

--- a/Configuration/SwaggerConfigurationInterface.php
+++ b/Configuration/SwaggerConfigurationInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Configuration;
+
+use EXSyst\Component\Swagger\Schema;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\DefinitionNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\OperationNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Exception\PathNotFoundException;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\MergeStrategyInterface;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+interface SwaggerConfigurationInterface
+{
+    /**
+     * Return swagger definition schema object
+     *
+     * @param string $definitionName
+     *
+     * @return Schema
+     *
+     * @throws DefinitionNotFoundException When swagger definition was not found
+     */
+    public function getDefinition(string $definitionName): Schema;
+
+    /**
+     * Returns merged swagger path operation by @see OperationParameterMerger
+     * according to specific @see MergeStrategyInterface
+     *
+     * @param string $routePath
+     * @param string $method
+     *
+     * @return Schema
+     *
+     * @throws OperationNotFoundException   When swagger operation was not found
+     * @throws PathNotFoundException        When swagger path was not found
+     */
+    public function getPathDefinition(string $routePath, string $method): Schema;
+}

--- a/DependencyInjection/LinkinSwaggerResolverExtension.php
+++ b/DependencyInjection/LinkinSwaggerResolverExtension.php
@@ -21,6 +21,7 @@ use Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterfa
 use Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerPhpConfigurationLoader;
 use Linkin\Bundle\SwaggerResolverBundle\Loader\YamlConfigurationLoader;
 use Linkin\Bundle\SwaggerResolverBundle\Merger\MergeStrategyInterface;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 use Linkin\Bundle\SwaggerResolverBundle\Normalizer\SwaggerNormalizerInterface;
 use Linkin\Bundle\SwaggerResolverBundle\Validator\SwaggerValidatorInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
@@ -97,6 +98,7 @@ class LinkinSwaggerResolverExtension extends Extension
     private function getConfigurationLoaderDefinition(ContainerBuilder $container, array $config): Definition
     {
         $loaderDefinition = new Definition();
+        $loaderDefinition->addArgument(new Reference(OperationParameterMerger::class));
 
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/DependencyInjection/LinkinSwaggerResolverExtension.php
+++ b/DependencyInjection/LinkinSwaggerResolverExtension.php
@@ -30,6 +30,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Routing\RouterInterface;
 use function class_exists;
 use function end;
 use function explode;
@@ -102,6 +103,7 @@ class LinkinSwaggerResolverExtension extends Extension
         if (isset($bundles['NelmioApiDocBundle'])) {
             return $loaderDefinition
                 ->setClass(NelmioApiDocConfigurationLoader::class)
+                ->addArgument(new Reference(RouterInterface::class))
                 ->addArgument(new Reference('nelmio_api_doc.generator'))
             ;
         }
@@ -116,6 +118,7 @@ class LinkinSwaggerResolverExtension extends Extension
 
             return $loaderDefinition
                 ->setClass(SwaggerPhpConfigurationLoader::class)
+                ->addArgument(new Reference(RouterInterface::class))
                 ->addArgument($scanDir)
                 ->addArgument($excludeDir)
             ;
@@ -132,7 +135,7 @@ class LinkinSwaggerResolverExtension extends Extension
         $explodedPath = explode('.', $pathToConfig);
         $extension = end($explodedPath);
 
-        if (class_exists('\Symfony\Component\Yaml\Yaml') && ('yaml' === $extension || 'yml' === $extension)) {
+        if ('yaml' === $extension || 'yml' === $extension) {
             return $loaderDefinition->setClass(YamlConfigurationLoader::class);
         }
 

--- a/Exception/NormalizationFailedException.php
+++ b/Exception/NormalizationFailedException.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Exception;
 
-use RuntimeException;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use function sprintf;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class NormalizationFailedException extends RuntimeException
+class NormalizationFailedException extends InvalidOptionsException
 {
     /**
      * @param string $propertyName

--- a/Exception/OperationNotFoundException.php
+++ b/Exception/OperationNotFoundException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Exception;
+
+use RuntimeException;
+use function sprintf;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+class OperationNotFoundException extends RuntimeException
+{
+    /**
+     * @param string $path
+     * @param string $method
+     */
+    public function __construct(string $path, string $method)
+    {
+        parent::__construct(sprintf('Swagger operation for path "%s" with "%s" was not found', $path, $method));
+    }
+}

--- a/Factory/SwaggerResolverFactory.php
+++ b/Factory/SwaggerResolverFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Factory;
 
 use Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder;
-use Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration;
+use Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfigurationInterface;
 use Linkin\Bundle\SwaggerResolverBundle\Resolver\SwaggerResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -38,18 +38,18 @@ class SwaggerResolverFactory
     private $router;
 
     /**
-     * @var SwaggerConfiguration
+     * @var SwaggerConfigurationInterface
      */
     private $swaggerConfiguration;
 
     /**
      * @param SwaggerResolverBuilder $builder
-     * @param SwaggerConfiguration $configuration
+     * @param SwaggerConfigurationInterface $configuration
      * @param RouterInterface $router
      */
     public function __construct(
         SwaggerResolverBuilder $builder,
-        SwaggerConfiguration $configuration,
+        SwaggerConfigurationInterface $configuration,
         RouterInterface $router
     ) {
         $this->builder = $builder;

--- a/Factory/SwaggerResolverFactory.php
+++ b/Factory/SwaggerResolverFactory.php
@@ -18,6 +18,9 @@ use Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration;
 use Linkin\Bundle\SwaggerResolverBundle\Resolver\SwaggerResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
+use function end;
+use function explode;
+use function strtolower;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -64,8 +67,9 @@ class SwaggerResolverFactory
         $pathInfo = $this->router->match($request->getPathInfo());
         $route = $this->router->getRouteCollection()->get($pathInfo['_route']);
         $routePath = $route->getPath();
+        $method = strtolower($request->getMethod());
 
-        $mergedSchema = $this->swaggerConfiguration->getPathDefinition($routePath, $request->getMethod());
+        $mergedSchema = $this->swaggerConfiguration->getPathDefinition($routePath, $method);
 
         return $this->builder->build($mergedSchema, $routePath);
     }
@@ -77,6 +81,9 @@ class SwaggerResolverFactory
      */
     public function createForDefinition(string $definitionName): SwaggerResolver
     {
+        $explodedName = explode('\\', $definitionName);
+        $definitionName = end($explodedName);
+
         $definition = $this->swaggerConfiguration->getDefinition($definitionName);
 
         return $this->builder->build($definition, $definitionName);

--- a/Loader/AbstractAnnotationConfigurationLoader.php
+++ b/Loader/AbstractAnnotationConfigurationLoader.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
+
+use EXSyst\Component\Swagger\Collections\Definitions;
+use EXSyst\Component\Swagger\Operation;
+use EXSyst\Component\Swagger\Parameter;
+use EXSyst\Component\Swagger\Path;
+use EXSyst\Component\Swagger\Swagger;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
+use function explode;
+use function reset;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+abstract class AbstractAnnotationConfigurationLoader implements SwaggerConfigurationLoaderInterface
+{
+    /**
+     * @var FileResource[][]
+     */
+    private $resources;
+
+    /**
+     * @var Route[]
+     */
+    private $routerCollection;
+
+    /**
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        foreach ($router->getRouteCollection() as $routeName => $route) {
+            $this->routerCollection[$route->getPath()] = $route;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileResources(string $definitionName): array
+    {
+        return $this->resources[$definitionName] ?? [];
+    }
+
+    /**
+     * @param Swagger $swagger
+     *
+     * @throws ReflectionException
+     */
+    protected function registerResources(Swagger $swagger): void
+    {
+        $this->registerDefinitionResources($swagger->getDefinitions());
+
+        /** @var Path $pathObject */
+        foreach ($swagger->getPaths()->getIterator() as $path => $pathObject) {
+            foreach ($pathObject->getOperations() as $method => $operation) {
+                $this->registerPathResources($path, $operation);
+            }
+        }
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return FileResource
+     *
+     * @throws ReflectionException
+     */
+    private function getFileResource(string $className)
+    {
+        $class = new ReflectionClass($className);
+
+        return new FileResource($class->getFileName());
+    }
+
+    /**
+     * @param Definitions $definitions
+     *
+     * @throws ReflectionException
+     */
+    private function registerDefinitionResources(Definitions $definitions): void
+    {
+        $definitionNames = [];
+
+        foreach ($definitions->getIterator() as $definitionName => $definition) {
+            $definitionNames[$definitionName] = $definitionName;
+        }
+
+        foreach (get_declared_classes() as $fullClassName) {
+            $explodedClassName = explode('\\', $fullClassName);
+            $className = end($explodedClassName);
+
+            if (!isset($definitionNames[$className])) {
+                continue;
+            }
+
+            $this->resources[$className][] = $this->getFileResource($fullClassName);
+        }
+    }
+
+    /**
+     * @param string $path
+     * @param Operation $operation
+     *
+     * @throws ReflectionException
+     */
+    private function registerPathResources(string $path, Operation $operation): void
+    {
+        $route = $this->routerCollection[$path];
+        $defaults = $route->getDefaults();
+        $exploded = explode('::', $defaults['_controller']);
+        $controllerName = reset($exploded);
+
+        $this->resources[$path][] = $this->getFileResource($controllerName);
+
+        /** @var Parameter $parameter */
+        foreach ($operation->getParameters()->getIterator() as $name => $parameter) {
+            $ref = $parameter->getSchema()->getRef();
+
+            if (!$ref) {
+                continue;
+            }
+
+            $explodedName = explode('/', $ref);
+            $definitionName = end($explodedName);
+
+            $refResources = $this->resources[$definitionName] ?? [];
+
+            foreach ($refResources as $fileResource) {
+                $this->resources[$path][] = $fileResource;
+            }
+        }
+    }
+}

--- a/Loader/AbstractFileConfigurationLoader.php
+++ b/Loader/AbstractFileConfigurationLoader.php
@@ -13,34 +13,31 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
-use EXSyst\Component\Swagger\Swagger;
-use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class YamlConfigurationLoader extends AbstractFileConfigurationLoader
+abstract class AbstractFileConfigurationLoader implements SwaggerConfigurationLoaderInterface
 {
     /**
-     * @var string
+     * @var FileResource[]
      */
-    private $pathToFile;
+    private $resources;
 
     /**
      * @param string $pathToFile
      */
     public function __construct(string $pathToFile)
     {
-        parent::__construct($pathToFile);
-
-        $this->pathToFile = $pathToFile;
+        $this->resources[] = new FileResource($pathToFile);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadConfiguration(): Swagger
+    public function getFileResources(string $definitionName): array
     {
-        return new Swagger(Yaml::parseFile($this->pathToFile));
+        return $this->resources;
     }
 }

--- a/Loader/AbstractFileConfigurationLoader.php
+++ b/Loader/AbstractFileConfigurationLoader.php
@@ -13,31 +13,49 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaDefinitionCollection;
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaOperationCollection;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-abstract class AbstractFileConfigurationLoader implements SwaggerConfigurationLoaderInterface
+abstract class AbstractFileConfigurationLoader extends AbstractSwaggerConfigurationLoader
 {
     /**
-     * @var FileResource[]
+     * @var FileResource
      */
-    private $resources;
+    private $fileResource;
 
     /**
+     * @param OperationParameterMerger $parameterMerger
      * @param string $pathToFile
      */
-    public function __construct(string $pathToFile)
+    public function __construct(OperationParameterMerger $parameterMerger, string $pathToFile)
     {
-        $this->resources[] = new FileResource($pathToFile);
+        parent::__construct($parameterMerger);
+
+        $this->fileResource = new FileResource($pathToFile);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getFileResources(string $definitionName): array
+    protected function registerDefinitionResources(SchemaDefinitionCollection $definitionCollection): void
     {
-        return $this->resources;
+        foreach ($definitionCollection->getIterator() as $definitionName => $schema) {
+            $definitionCollection->addSchemaResource($definitionName, $this->fileResource);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerOperationResources(SchemaOperationCollection $operationCollection): void
+    {
+        foreach ($operationCollection->getIterator() as $path => $methodList) {
+            $operationCollection->addSchemaResource($path, $this->fileResource);
+        }
     }
 }

--- a/Loader/AbstractSwaggerConfigurationLoader.php
+++ b/Loader/AbstractSwaggerConfigurationLoader.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SwaggerResolverBundle package.
+ *
+ * (c) Viktor Linkin <adrenalinkin@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
+
+use EXSyst\Component\Swagger\Operation;
+use EXSyst\Component\Swagger\Parameter;
+use EXSyst\Component\Swagger\Path;
+use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaDefinitionCollection;
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaOperationCollection;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
+use function end;
+use function explode;
+
+/**
+ * @author Viktor Linkin <adrenalinkin@gmail.com>
+ */
+abstract class AbstractSwaggerConfigurationLoader implements SwaggerConfigurationLoaderInterface
+{
+    /**
+     * @var SchemaDefinitionCollection
+     */
+    private $definitionCollection;
+
+    /**
+     * @var SchemaOperationCollection
+     */
+    private $operationCollection;
+
+    /**
+     * @var OperationParameterMerger
+     */
+    private $parameterMerger;
+
+    /**
+     * @param OperationParameterMerger $parameterMerger
+     */
+    public function __construct(OperationParameterMerger $parameterMerger)
+    {
+        $this->parameterMerger = $parameterMerger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSchemaDefinitionCollection(): SchemaDefinitionCollection
+    {
+        if (!$this->definitionCollection) {
+            $this->registerCollections();
+        }
+
+        return $this->definitionCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSchemaOperationCollection(): SchemaOperationCollection
+    {
+        if (!$this->operationCollection) {
+            $this->registerCollections();
+        }
+
+        return $this->operationCollection;
+    }
+
+    /**
+     * Load full configuration and returns Swagger object
+     *
+     * @return Swagger
+     */
+    abstract protected function loadConfiguration(): Swagger;
+
+    /**
+     * Add file resources for swagger definitions
+     *
+     * @param SchemaDefinitionCollection $definitionCollection
+     */
+    abstract protected function registerDefinitionResources(SchemaDefinitionCollection $definitionCollection): void;
+
+    /**
+     * Add file resources for swagger operations
+     *
+     * @param SchemaOperationCollection $operationCollection
+     */
+    abstract protected function registerOperationResources(SchemaOperationCollection $operationCollection): void;
+
+    /**
+     * Register collection according to loaded Swagger object
+     */
+    private function registerCollections(): void
+    {
+        $swaggerConfiguration = $this->loadConfiguration();
+
+        $definitionCollection = new SchemaDefinitionCollection();
+        $operationCollection = new SchemaOperationCollection();
+
+        foreach ($swaggerConfiguration->getDefinitions()->getIterator() as $definitionName => $definition) {
+            $definitionCollection->addSchema($definitionName, $definition);
+        }
+
+        $this->registerDefinitionResources($definitionCollection);
+
+        /** @var Path $pathObject */
+        foreach ($swaggerConfiguration->getPaths()->getIterator() as $path => $pathObject) {
+            /** @var Operation $operation */
+            foreach ($pathObject->getOperations() as $method => $operation) {
+                $schema = $this->parameterMerger->merge($operation, $swaggerConfiguration->getDefinitions());
+                $operationCollection->addSchema($path, $method, $schema);
+
+                /** @var Parameter $parameter */
+                foreach ($operation->getParameters()->getIterator() as $name => $parameter) {
+                    $ref = $parameter->getSchema()->getRef();
+
+                    if (!$ref) {
+                        continue;
+                    }
+
+                    $explodedName = explode('/', $ref);
+                    $definitionName = end($explodedName);
+
+                    foreach ($definitionCollection->getSchemaResources($definitionName) as $fileResource) {
+                        $operationCollection->addSchemaResource($path, $fileResource);
+                    }
+                }
+            }
+        }
+
+        $this->registerOperationResources($operationCollection);
+
+        $this->definitionCollection = $definitionCollection;
+        $this->operationCollection = $operationCollection;
+    }
+}

--- a/Loader/JsonConfigurationLoader.php
+++ b/Loader/JsonConfigurationLoader.php
@@ -18,7 +18,7 @@ use EXSyst\Component\Swagger\Swagger;
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class JsonConfigurationLoader implements SwaggerConfigurationLoaderInterface
+class JsonConfigurationLoader extends AbstractFileConfigurationLoader
 {
     /**
      * @var string
@@ -30,6 +30,8 @@ class JsonConfigurationLoader implements SwaggerConfigurationLoaderInterface
      */
     public function __construct(string $pathToFile)
     {
+        parent::__construct($pathToFile);
+
         $this->pathToFile = $pathToFile;
     }
 

--- a/Loader/JsonConfigurationLoader.php
+++ b/Loader/JsonConfigurationLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -26,11 +27,12 @@ class JsonConfigurationLoader extends AbstractFileConfigurationLoader
     private $pathToFile;
 
     /**
+     * @param OperationParameterMerger $parameterMerger
      * @param string $pathToFile
      */
-    public function __construct(string $pathToFile)
+    public function __construct(OperationParameterMerger $parameterMerger, string $pathToFile)
     {
-        parent::__construct($pathToFile);
+        parent::__construct($parameterMerger, $pathToFile);
 
         $this->pathToFile = $pathToFile;
     }
@@ -38,7 +40,7 @@ class JsonConfigurationLoader extends AbstractFileConfigurationLoader
     /**
      * {@inheritdoc}
      */
-    public function loadConfiguration(): Swagger
+    protected function loadConfiguration(): Swagger
     {
         return Swagger::fromFile($this->pathToFile);
     }

--- a/Loader/NelmioApiDocConfigurationLoader.php
+++ b/Loader/NelmioApiDocConfigurationLoader.php
@@ -15,11 +15,12 @@ namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
 use Nelmio\ApiDocBundle\ApiDocGenerator;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class NelmioApiDocConfigurationLoader implements SwaggerConfigurationLoaderInterface
+class NelmioApiDocConfigurationLoader extends AbstractAnnotationConfigurationLoader
 {
     /**
      * Instance of nelmio Api configuration generator
@@ -29,10 +30,13 @@ class NelmioApiDocConfigurationLoader implements SwaggerConfigurationLoaderInter
     private $apiDocGenerator;
 
     /**
+     * @param RouterInterface $router
      * @param ApiDocGenerator $apiDocGenerator
      */
-    public function __construct(ApiDocGenerator $apiDocGenerator)
+    public function __construct(RouterInterface $router, ApiDocGenerator $apiDocGenerator)
     {
+        parent::__construct($router);
+
         $this->apiDocGenerator = $apiDocGenerator;
     }
 
@@ -42,6 +46,8 @@ class NelmioApiDocConfigurationLoader implements SwaggerConfigurationLoaderInter
     public function loadConfiguration(): Swagger
     {
         $swagger = $this->apiDocGenerator->generate();
+
+        $this->registerResources($swagger);
 
         return $swagger;
     }

--- a/Loader/NelmioApiDocConfigurationLoader.php
+++ b/Loader/NelmioApiDocConfigurationLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 use Nelmio\ApiDocBundle\ApiDocGenerator;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -30,25 +31,22 @@ class NelmioApiDocConfigurationLoader extends AbstractAnnotationConfigurationLoa
     private $apiDocGenerator;
 
     /**
+     * @param OperationParameterMerger $merger
      * @param RouterInterface $router
-     * @param ApiDocGenerator $apiDocGenerator
+     * @param ApiDocGenerator $generator
      */
-    public function __construct(RouterInterface $router, ApiDocGenerator $apiDocGenerator)
+    public function __construct(OperationParameterMerger $merger, RouterInterface $router, ApiDocGenerator $generator)
     {
-        parent::__construct($router);
+        parent::__construct($merger, $router);
 
-        $this->apiDocGenerator = $apiDocGenerator;
+        $this->apiDocGenerator = $generator;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadConfiguration(): Swagger
+    protected function loadConfiguration(): Swagger
     {
-        $swagger = $this->apiDocGenerator->generate();
-
-        $this->registerResources($swagger);
-
-        return $swagger;
+        return $this->apiDocGenerator->generate();
     }
 }

--- a/Loader/SwaggerConfigurationLoaderInterface.php
+++ b/Loader/SwaggerConfigurationLoaderInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
-use EXSyst\Component\Swagger\Swagger;
-use Symfony\Component\Config\Resource\FileResource;
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaDefinitionCollection;
+use Linkin\Bundle\SwaggerResolverBundle\Collection\SchemaOperationCollection;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -22,18 +22,17 @@ use Symfony\Component\Config\Resource\FileResource;
 interface SwaggerConfigurationLoaderInterface
 {
     /**
-     * Returns list of the file resources where configuration located
+     * Return swagger definition schema collection
      *
-     * @param string $definitionName
-     *
-     * @return FileResource[]
+     * @return SchemaDefinitionCollection
      */
-    public function getFileResources(string $definitionName): array;
+    public function getSchemaDefinitionCollection(): SchemaDefinitionCollection;
 
     /**
-     * Loads swagger configuration
+     * Returns collection of the merged swagger path operation by @see OperationParameterMerger
+     * according to specific @see MergeStrategyInterface
      *
-     * @return Swagger
+     * @return SchemaOperationCollection
      */
-    public function loadConfiguration(): Swagger;
+    public function getSchemaOperationCollection(): SchemaOperationCollection;
 }

--- a/Loader/SwaggerConfigurationLoaderInterface.php
+++ b/Loader/SwaggerConfigurationLoaderInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
@@ -21,7 +22,16 @@ use EXSyst\Component\Swagger\Swagger;
 interface SwaggerConfigurationLoaderInterface
 {
     /**
-     * Loads swagger configuration from the annotations.
+     * Returns list of the file resources where configuration located
+     *
+     * @param string $definitionName
+     *
+     * @return FileResource[]
+     */
+    public function getFileResources(string $definitionName): array;
+
+    /**
+     * Loads swagger configuration
      *
      * @return Swagger
      */

--- a/Loader/SwaggerPhpConfigurationLoader.php
+++ b/Loader/SwaggerPhpConfigurationLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 use Symfony\Component\Routing\RouterInterface;
 use function json_decode;
 use function Swagger\scan;
@@ -34,13 +35,14 @@ class SwaggerPhpConfigurationLoader extends AbstractAnnotationConfigurationLoade
     private $scan;
 
     /**
+     * @param OperationParameterMerger $merger
      * @param RouterInterface $router
      * @param array $scan
      * @param array $exclude
      */
-    public function __construct(RouterInterface $router, array $scan, array $exclude)
+    public function __construct(OperationParameterMerger $merger, RouterInterface $router, array $scan, array $exclude)
     {
-        parent::__construct($router);
+        parent::__construct($merger, $router);
 
         $this->scan = $scan;
         $this->exclude = $exclude;
@@ -49,15 +51,13 @@ class SwaggerPhpConfigurationLoader extends AbstractAnnotationConfigurationLoade
     /**
      * {@inheritdoc}
      */
-    public function loadConfiguration(): Swagger
+    protected function loadConfiguration(): Swagger
     {
         $swaggerAnnotation = scan($this->scan, [
             'exclude' => $this->exclude,
         ]);
 
         $swagger = new Swagger(json_decode((string) $swaggerAnnotation, true));
-
-        $this->registerResources($swagger);
 
         return $swagger;
     }

--- a/Loader/SwaggerPhpConfigurationLoader.php
+++ b/Loader/SwaggerPhpConfigurationLoader.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Symfony\Component\Routing\RouterInterface;
 use function json_decode;
 use function Swagger\scan;
 
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class SwaggerPhpConfigurationLoader implements SwaggerConfigurationLoaderInterface
+class SwaggerPhpConfigurationLoader extends AbstractAnnotationConfigurationLoader
 {
     /**
      * @var array
@@ -33,11 +34,14 @@ class SwaggerPhpConfigurationLoader implements SwaggerConfigurationLoaderInterfa
     private $scan;
 
     /**
+     * @param RouterInterface $router
      * @param array $scan
      * @param array $exclude
      */
-    public function __construct(array $scan, array $exclude)
+    public function __construct(RouterInterface $router, array $scan, array $exclude)
     {
+        parent::__construct($router);
+
         $this->scan = $scan;
         $this->exclude = $exclude;
     }
@@ -52,6 +56,8 @@ class SwaggerPhpConfigurationLoader implements SwaggerConfigurationLoaderInterfa
         ]);
 
         $swagger = new Swagger(json_decode((string) $swaggerAnnotation, true));
+
+        $this->registerResources($swagger);
 
         return $swagger;
     }

--- a/Loader/YamlConfigurationLoader.php
+++ b/Loader/YamlConfigurationLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Loader;
 
 use EXSyst\Component\Swagger\Swagger;
+use Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -27,11 +28,12 @@ class YamlConfigurationLoader extends AbstractFileConfigurationLoader
     private $pathToFile;
 
     /**
+     * @param OperationParameterMerger $parameterMerger
      * @param string $pathToFile
      */
-    public function __construct(string $pathToFile)
+    public function __construct(OperationParameterMerger $parameterMerger, string $pathToFile)
     {
-        parent::__construct($pathToFile);
+        parent::__construct($parameterMerger, $pathToFile);
 
         $this->pathToFile = $pathToFile;
     }
@@ -39,7 +41,7 @@ class YamlConfigurationLoader extends AbstractFileConfigurationLoader
     /**
      * {@inheritdoc}
      */
-    public function loadConfiguration(): Swagger
+    protected function loadConfiguration(): Swagger
     {
         return new Swagger(Yaml::parseFile($this->pathToFile));
     }

--- a/Merger/OperationParameterMerger.php
+++ b/Merger/OperationParameterMerger.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Linkin\Bundle\SwaggerResolverBundle\Merger;
 
 use EXSyst\Component\Swagger\Collections\Definitions;
+use EXSyst\Component\Swagger\Operation;
 use EXSyst\Component\Swagger\Parameter;
-use EXSyst\Component\Swagger\Path;
 use EXSyst\Component\Swagger\Schema;
 use Linkin\Bundle\SwaggerResolverBundle\Enum\ParameterLocationEnum;
 use function array_flip;
@@ -25,7 +25,7 @@ use function explode;
 /**
  * @author Viktor Linkin <adrenalinkin@gmail.com>
  */
-class PathParameterMerger
+class OperationParameterMerger
 {
     /**
      * @var MergeStrategyInterface
@@ -41,16 +41,13 @@ class PathParameterMerger
     }
 
     /**
-     * @param Path $swaggerPath
-     * @param string $requestMethod
+     * @param Operation $swaggerOperation
      * @param Definitions $definitions
      *
      * @return Schema
      */
-    public function merge(Path $swaggerPath, string $requestMethod, Definitions $definitions): Schema
+    public function merge(Operation $swaggerOperation, Definitions $definitions): Schema
     {
-        $swaggerOperation = $swaggerPath->getOperation($requestMethod);
-
         /** @var Parameter $parameter */
         foreach ($swaggerOperation->getParameters() as $parameter) {
             if ($parameter->getIn() !== ParameterLocationEnum::IN_BODY) {

--- a/README.RU.md
+++ b/README.RU.md
@@ -84,7 +84,7 @@ linkin_swagger_resolver:
         - 'query'
         - 'path'
         - 'header'
-    # стратегия по умолчанию для слияния параметров запроса
+    # стратегия для слияния параметров запроса
     path_merge_strategy:            Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy
     configuration_loader_service:   ~   # имя сервиса загрузки конфигурации
     configuration_file:             ~   # полный путь к файлу конфигурации

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ linkin_swagger_resolver:
         - 'query'
         - 'path'
         - 'header'
-    # default strategy for merge all request parameters.
+    # strategy for merge all request parameters.
     path_merge_strategy:            Linkin\Bundle\SwaggerResolverBundle\Merger\Strategy\StrictMergeStrategy
     configuration_loader_service:   ~   # the name of the configuration loader service
     configuration_file:             ~   # full path to the configuration file

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -5,16 +5,29 @@ services:
             - [] # normalizers
             - '%linkin_swagger_resolver.enable_normalization%'
 
+    Linkin\Bundle\SwaggerResolverBundle\CacheWarmer\SwaggerConfigurationCacheWarmer:
+        arguments:
+            - '@Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfigurationInterface'
+        tags:
+            - { name: kernel.cache_warmer }
+
+    Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfigurationInterface:
+        alias: Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerCachedConfiguration
     Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration:
         arguments:
             - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
+    Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerCachedConfiguration:
+        parent: Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration
+        calls:
+            - [setCacheDir, ['%kernel.cache_dir%']]
+            - [setDebugMode, ['%kernel.debug%']]
 
     Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
         public: true
         arguments:
             - '@Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder'
-            - '@Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfigurationInterface'
             - '@router'
     linkin_swagger_resolver.factory:
         alias: Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -18,10 +18,11 @@ services:
             - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
     Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerCachedConfiguration:
-        parent: Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration
-        calls:
-            - [setCacheDir, ['%kernel.cache_dir%']]
-            - [setDebugMode, ['%kernel.debug%']]
+        arguments:
+            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
+            - '%kernel.cache_dir%'
+            - '%kernel.debug%'
 
     Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
         public: true

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -5,12 +5,16 @@ services:
             - [] # normalizers
             - '%linkin_swagger_resolver.enable_normalization%'
 
+    Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration:
+        arguments:
+            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
+
     Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
         public: true
         arguments:
             - '@Linkin\Bundle\SwaggerResolverBundle\Builder\SwaggerResolverBuilder'
-            - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
-            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration'
             - '@router'
     linkin_swagger_resolver.factory:
         alias: Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -7,7 +7,7 @@ services:
 
     Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration:
         arguments:
-            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger'
+            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
 
     Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory:
@@ -19,7 +19,7 @@ services:
     linkin_swagger_resolver.factory:
         alias: Linkin\Bundle\SwaggerResolverBundle\Factory\SwaggerResolverFactory
 
-    Linkin\Bundle\SwaggerResolverBundle\Merger\PathParameterMerger:
+    Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger:
         arguments:
             - '@Linkin\Bundle\SwaggerResolverBundle\Merger\MergeStrategyInterface'
 

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -15,11 +15,9 @@ services:
         alias: Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerCachedConfiguration
     Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerConfiguration:
         arguments:
-            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
     Linkin\Bundle\SwaggerResolverBundle\Configuration\SwaggerCachedConfiguration:
         arguments:
-            - '@Linkin\Bundle\SwaggerResolverBundle\Merger\OperationParameterMerger'
             - '@Linkin\Bundle\SwaggerResolverBundle\Loader\SwaggerConfigurationLoaderInterface'
             - '%kernel.cache_dir%'
             - '%kernel.debug%'

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,19 @@
     "name":        "adrenalinkin/swagger-resolver-bundle",
     "description": "Provides possibility for validate data according to Swagger documentation",
     "type":        "symfony-bundle",
-    "keywords":    ["symfony-bundle", "api", "open-api-2", "swagger", "swagger-php", "resolver", "validation"],
     "license":     "MIT",
+    "keywords":    [
+        "symfony-bundle",
+        "api",
+        "documentation",
+        "api-documentation",
+        "open-api",
+        "swagger",
+        "swagger-php",
+        "resolver",
+        "validation",
+        "api-validation"
+    ],
 
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         "exsyst/swagger":               "~0.4",
         "symfony/config":               "~3.4||~4.0",
         "symfony/dependency-injection": "~3.4||~4.0",
+        "symfony/http-foundation":      "~3.4||~4.0",
         "symfony/http-kernel":          "~3.4||~4.0",
         "symfony/options-resolver":     "~3.4||~4.0",
         "symfony/routing":              "~3.4||~4.0",
-        "symfony/http-foundation":      "~3.4||~4.0"
+        "symfony/yaml":                 "~3.4||~4.0"
     },
 
     "suggest": {
         "nelmio/api-doc-bundle":    "Generates documentation for your REST API from annotations",
         "symfony/symfony":          "Allows more advanced functionality with full Symfony package",
-        "symfony/yaml":             "Allows to define Swagger configuration in yaml file",
         "zircote/swagger-php":      "Allows to generate Swagger configuration by php annotations"
     },
 


### PR DESCRIPTION
Resolve #5 
- Added symfony cache warmer for the swagger configuration and enable him by default.
- Added console notification when some api definitions have not reference to the source file.
- Added automatic cache warm up in the debug mode, according to source file modification.
- Added composer requirement: `symfony/yaml`.
- Extend `NormalizationFailedException` from `InvalidOptionsException` instead `RuntimeException`.
- Removed possibility set `MergeStrategyInterface` for single call `SwaggerResolverFactory::createForRequest`.
- Renamed `PathParameterMerger` into `OperationParameterMerger`.
- Reworked `SwaggerConfigurationLoaderInterface`.